### PR TITLE
Improving error handling for command control

### DIFF
--- a/bin/devdeck
+++ b/bin/devdeck
@@ -3,23 +3,39 @@ import logging
 import os
 import sys
 import threading
+from logging.handlers import RotatingFileHandler
 from pathlib import Path
 
 from StreamDeck.DeviceManager import DeviceManager
 
 from devdeck.devdeck import DevDeck
+from devdeck.logging.filters import InfoFilter
 from devdeck.settings.devdeck_settings import DevDeckSettings
 from devdeck.settings.validation_error import ValidationError
 
 if __name__ == "__main__":
+    os.makedirs(os.path.join(str(Path.home()), '.devdeck'), exist_ok=True)
+
     root = logging.getLogger('devdeck')
     root.setLevel(logging.DEBUG)
 
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setLevel(logging.INFO)
     formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    handler.setFormatter(formatter)
-    root.addHandler(handler)
+
+    info_handler = logging.StreamHandler(sys.stdout)
+    info_handler.setLevel(logging.INFO)
+    info_handler.setFormatter(formatter)
+    info_handler.addFilter(InfoFilter())
+    root.addHandler(info_handler)
+
+    error_handler = logging.StreamHandler(sys.stderr)
+    error_handler.setLevel(logging.WARNING)
+    error_handler.setFormatter(formatter)
+    root.addHandler(error_handler)
+
+    fileHandler = RotatingFileHandler(os.path.join(str(Path.home()), '.devdeck', 'devdeck.log'), maxBytes=100000,
+                                      backupCount=5)
+    fileHandler.setFormatter(formatter)
+    root.addHandler(fileHandler)
 
     streamdecks = DeviceManager().enumerate()
 
@@ -34,7 +50,6 @@ if __name__ == "__main__":
             deck.close()
         if len(serial_numbers) > 0:
             root.info("Generating a setting file as none exist: %s", settings_filename)
-            os.makedirs(os.path.join(str(Path.home()), '.devdeck'), exist_ok=True)
             DevDeckSettings.generate_default(settings_filename, serial_numbers)
         else:
             root.info("""No stream deck connected. Please connect a stream deck to generate an initial config file. \n

--- a/devdeck/controls/command_control.py
+++ b/devdeck/controls/command_control.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from subprocess import Popen, DEVNULL
 
@@ -5,10 +6,17 @@ from devdeck_core.controls.deck_control import DeckControl
 
 
 class CommandControl(DeckControl):
+    def __init__(self, key_no, **kwargs):
+        self.__logger = logging.getLogger('devdeck')
+        super().__init__(key_no, **kwargs)
+
     def initialize(self):
         with self.deck_context() as context:
             with context.renderer() as r:
                 r.image(os.path.expanduser(self.settings['icon'])).end()
 
     def pressed(self):
-        Popen(self.settings['command'], stdout=DEVNULL, stderr=DEVNULL)
+        try:
+            Popen(self.settings['command'], stdout=DEVNULL, stderr=DEVNULL)
+        except Exception as ex:
+            self.__logger.error("Error executing command %s: %s", self.settings['command'], str(ex))

--- a/devdeck/logging/filters.py
+++ b/devdeck/logging/filters.py
@@ -1,0 +1,6 @@
+import logging
+
+
+class InfoFilter(logging.Filter):
+    def filter(self, rec):
+        return rec.levelno in (logging.DEBUG, logging.INFO)


### PR DESCRIPTION
Improvements as a result of investigating #7 

`CommandControl` uses `Popen` which is non-blocking by default, but, what I did notice is if you provide a bad command, a `FileNotFound` error is unhandled and crashes devdeck.

This change has the following improvements:
* Split error/warning and info/debug between stderr and stdout
* Write all lots to `~/.devdeck/devdeck.log`
* Handle any exceptions caused by trying to launch a command